### PR TITLE
入力がなかった時のテーマに対して入力なしを表示

### DIFF
--- a/src/app/(authenticated)/MemoEditor/page.tsx
+++ b/src/app/(authenticated)/MemoEditor/page.tsx
@@ -72,7 +72,7 @@ const MemoEditorPage = () => {
               id: responseData.id,
               content: inputContentRef.current,
               created_at: responseData.created_at,
-              local_created_at: new Date().toISOString(),
+              local_created_at: responseData.created_at,
               theme: currentTheme,
             };
             console.log("Memo saved to DB:", inputContentRef.current);

--- a/src/app/(authenticated)/MemoList/page.tsx
+++ b/src/app/(authenticated)/MemoList/page.tsx
@@ -1,8 +1,7 @@
 "use client";
-import { useAtomValue, useSetAtom } from "jotai";
-import { useEffect, useRef } from "react";
+import { useAtomValue } from "jotai";
 
-import { countTheme, recentMemosAtom } from "@/store";
+import { countTheme, recentMemosAtom, themeAtom } from "@/store";
 import type { Memo } from "@/types/database";
 
 // HTMLタグを除去し、改行を「/」で置き換える関数
@@ -18,10 +17,37 @@ const formatContent = (html: string) => {
   return paragraphs.join(" ｜ ");
 };
 
-const MemoForView = ({ memo }: { memo: Memo }) => {
-  const date = new Date(memo.local_created_at);
-  const formattedDate = date.toLocaleDateString("ja-JP");
-  const formattedTime = date.toLocaleTimeString("ja-JP");
+const MemoForView = ({
+  memo,
+  theme,
+}: {
+  memo: Memo | null;
+  theme: { id: string; theme: string };
+}) => {
+  if (!memo) {
+    const date = new Date();
+    const formattedDate = date.toLocaleDateString();
+    const formattedTime = date.toLocaleTimeString(undefined, {
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+    return (
+      <li className="mb-4 list-none">
+        <p className="text-sm text-gray">
+          {formattedDate}: {formattedTime}
+        </p>
+        <p className="text-sm text-gray">{theme.theme}</p>
+        <p className="text-sm text-gray">入力なし</p>
+      </li>
+    );
+  }
+
+  const date = new Date(memo.created_at);
+  const formattedDate = date.toLocaleDateString();
+  const formattedTime = date.toLocaleTimeString(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
   return (
     <li
       key={`${formattedDate}-${formattedTime}-${memo.theme.theme}`}
@@ -39,50 +65,25 @@ const MemoForView = ({ memo }: { memo: Memo }) => {
 
 export default function MemoListPage() {
   const recentMemos = useAtomValue(recentMemosAtom);
-  const setRecentMemos = useSetAtom(recentMemosAtom);
   const themeCount = useAtomValue(countTheme);
-  const lastDateRef = useRef<string | null>(null);
+  const themes = useAtomValue(themeAtom);
 
-  useEffect(() => {
-    const checkDateChange = () => {
-      const currentDate = new Date().toLocaleDateString();
-
-      if (lastDateRef.current === null) {
-        // 初回実行時は日付を保存
-        lastDateRef.current = currentDate;
-      } else if (lastDateRef.current !== currentDate) {
-        // 日付が変わったらメモをクリア
-        setRecentMemos([]);
-        lastDateRef.current = currentDate;
-      }
-    };
-
-    // 初回実行
-    checkDateChange();
-
-    // 1分ごとに日付をチェック
-    const intervalId = setInterval(checkDateChange, 60000);
-
-    return () => {
-      clearInterval(intervalId);
-    };
-  }, [setRecentMemos]);
-
-  // 最新のメモを取得（作成日時の降順でソート）し、theme_countの件数分のみを表示
-  const sortedMemos = [...recentMemos]
-    .sort(
-      (a, b) =>
-        new Date(b.local_created_at).getTime() -
-        new Date(a.local_created_at).getTime()
-    )
-    .slice(0, themeCount);
+  // テーマごとの最新のメモを取得
+  const themeMemos = themes.slice(0, themeCount).map((theme) => {
+    const memoForTheme = recentMemos.find((memo) => memo.theme.id === theme.id);
+    return memoForTheme || null;
+  });
 
   return (
     <div className="flex flex-col items-center justify-center">
       <h1 className="mb-5 text-xl font-bold">保存されたメモ</h1>
       <ul className="w-2/3 list-disc">
-        {sortedMemos.map((memo) => (
-          <MemoForView key={memo.id} memo={memo} />
+        {themeMemos.map((memo, index) => (
+          <MemoForView
+            key={themes[index].id}
+            memo={memo}
+            theme={themes[index]}
+          />
         ))}
       </ul>
     </div>

--- a/src/app/(authenticated)/MemoListAll/page.tsx
+++ b/src/app/(authenticated)/MemoListAll/page.tsx
@@ -37,6 +37,14 @@ const formatDate = (dateString: string) => {
   return `${year}/${month}/${day} ${time}`;
 };
 
+// 時間をローカルタイムゾーンでフォーマットする関数
+const formatTime = (dateString: string) => {
+  const date = new Date(dateString);
+  const hours = date.getHours().toString().padStart(2, '0');
+  const minutes = date.getMinutes().toString().padStart(2, '0');
+  return `${hours}:${minutes}`;
+};
+
 const MemoListAllPage: FC = () => {
   const [filteredMemos, setFilteredMemos] = useState<Memo[]>([]); // フィルタリングされたメモのリストを管理
   const [themes, setThemes] = useState<{ id: string; theme: string }[]>([]); // テーマのステートを追加
@@ -184,7 +192,7 @@ const MemoListAllPage: FC = () => {
             className="mb-4 list-none"
           >
             <p className="text-center text-xs font-thin text-gray">
-              {formatDate(memo.created_at)}
+              {formatDate(memo.created_at)}&nbsp;{formatTime(memo.created_at)}
             </p>
             <p className="my-2 w-full text-xs font-thin">
               {memo.title} - {memo.theme.theme}


### PR DESCRIPTION
メモ入力にて設定したテーマ数以下の入力すると過去分が表示される対策として、

- 入力分の数のメモを表示するのではなく、入力なしのテーマには「入力なし」を表示（お題のテーマが何だったのか、何をスキップしたかわかった方が良いような気がして）

微細な変更ですが、memoListAllページにもメモの隣に入力時間が表示しました