### PR TITLE
Pj1 46 introduce drawing in memo editor（ 描画メモの保存と表示を実装）

### DIFF
--- a/src/app/(authenticated)/MemoEditor/page.tsx
+++ b/src/app/(authenticated)/MemoEditor/page.tsx
@@ -125,7 +125,7 @@ const MemoEditorPage = () => {
             const newMemo = {
               id: responseData.id,
               title: "描画メモ",
-              content: drawingContentRef.current,
+              content: responseData.content,
               created_at: responseData.created_at,
               local_created_at: responseData.created_at,
               theme: currentTheme,

--- a/src/app/(authenticated)/MemoList/page.tsx
+++ b/src/app/(authenticated)/MemoList/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useAtomValue } from "jotai";
+import Image from "next/image";
 
 import { countTheme, recentMemosAtom, themeAtom } from "@/store";
 import type { Memo } from "@/types/database";
@@ -58,7 +59,21 @@ const MemoForView = ({
       </p>
       <p className="text-sm text-gray">{memo.theme.theme}</p>
       {/* メモの内容をフォーマットして表示 */}
-      <p>{formatContent(memo.content)}</p>
+      {memo.content && memo.content.trim() !== "" ? (
+        memo.content.startsWith("data:image") ? (
+          <Image
+            src={memo.content}
+            alt="描画内容"
+            width={800}
+            height={400}
+            className="mt-2 max-w-full rounded border border-lightGray"
+          />
+        ) : (
+          <p>{formatContent(memo.content)}</p>
+        )
+      ) : (
+        <p className="text-sm text-gray">入力なし</p>
+      )}
     </li>
   );
 };
@@ -71,8 +86,12 @@ export default function MemoListPage() {
   // テーマごとの最新のメモを取得
   const themeMemos = themes.slice(0, themeCount).map((theme) => {
     const memoForTheme = recentMemos.find((memo) => memo.theme.id === theme.id);
+    console.log("Found memo for theme:", theme.id, memoForTheme);
     return memoForTheme || null;
   });
+
+  console.log("Recent memos:", recentMemos);
+  console.log("Theme memos:", themeMemos);
 
   return (
     <div className="flex flex-col items-center justify-center">

--- a/src/app/(authenticated)/MemoList/page.tsx
+++ b/src/app/(authenticated)/MemoList/page.tsx
@@ -65,7 +65,7 @@ const MemoForView = ({
             src={memo.content}
             alt="描画内容"
             width={800}
-            height={400}
+            height={300}
             className="mt-2 max-w-full rounded border border-lightGray"
           />
         ) : (

--- a/src/app/(authenticated)/MemoListAll/page.tsx
+++ b/src/app/(authenticated)/MemoListAll/page.tsx
@@ -204,7 +204,7 @@ const MemoListAllPage: FC = () => {
                   src={memo.content}
                   alt="描画内容"
                   width={800}
-                  height={400}
+                  height={300}
                   className="mt-2 max-w-full rounded border border-lightGray"
                 />
               ) : (

--- a/src/app/(authenticated)/MemoListAll/page.tsx
+++ b/src/app/(authenticated)/MemoListAll/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useAtomValue, useSetAtom } from "jotai";
 import ky from "ky";
+import Image from "next/image";
 import { type FC, useEffect, useState } from "react";
 
 import { memoListAtom } from "@/store";
@@ -40,8 +41,8 @@ const formatDate = (dateString: string) => {
 // 時間をローカルタイムゾーンでフォーマットする関数
 const formatTime = (dateString: string) => {
   const date = new Date(dateString);
-  const hours = date.getHours().toString().padStart(2, '0');
-  const minutes = date.getMinutes().toString().padStart(2, '0');
+  const hours = date.getHours().toString().padStart(2, "0");
+  const minutes = date.getMinutes().toString().padStart(2, "0");
   return `${hours}:${minutes}`;
 };
 
@@ -197,7 +198,20 @@ const MemoListAllPage: FC = () => {
             <p className="my-2 w-full text-xs font-thin">
               {memo.title} - {memo.theme.theme}
             </p>
-            <p className="w-full break-words">{formatContent(memo.content)}</p>
+            {memo.content &&
+              (memo.content.startsWith("data:image") ? (
+                <Image
+                  src={memo.content}
+                  alt="描画内容"
+                  width={800}
+                  height={400}
+                  className="mt-2 max-w-full rounded border border-lightGray"
+                />
+              ) : (
+                <p className="w-full break-words">
+                  {formatContent(memo.content)}
+                </p>
+              ))}
           </li>
         ))}
       </ul>

--- a/src/component/Drawing.tsx
+++ b/src/component/Drawing.tsx
@@ -1,0 +1,99 @@
+"use client";
+import { useEffect, useRef, useState } from "react";
+
+interface DrawingProps {
+  onChange: (value: string) => void;
+  value: string;
+}
+
+export const Drawing: React.FC<DrawingProps> = ({ onChange, value }) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [isDrawing, setIsDrawing] = useState(false);
+  const [context, setContext] = useState<CanvasRenderingContext2D | null>(null);
+  const [canvasWidth, setCanvasWidth] = useState(800);
+
+  useEffect(() => {
+    // 画面幅の70%を計算
+    const width = window.innerWidth * 0.7;
+    setCanvasWidth(width);
+  }, []);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    ctx.lineWidth = 2;
+    ctx.lineCap = "round";
+    ctx.lineJoin = "round";
+    ctx.strokeStyle = "#000000";
+    setContext(ctx);
+
+    // 保存された画像がある場合は表示
+    if (value) {
+      const img = new Image();
+      img.onload = () => {
+        ctx.drawImage(img, 0, 0);
+      };
+      img.src = value;
+    }
+  }, [value]);
+
+  const startDrawing = (e: React.MouseEvent<HTMLCanvasElement>) => {
+    if (!context) return;
+    const { offsetX, offsetY } = e.nativeEvent;
+    context.beginPath();
+    context.moveTo(offsetX, offsetY);
+    setIsDrawing(true);
+  };
+
+  const draw = (e: React.MouseEvent<HTMLCanvasElement>) => {
+    if (!isDrawing || !context) return;
+    const { offsetX, offsetY } = e.nativeEvent;
+    context.lineTo(offsetX, offsetY);
+    context.stroke();
+  };
+
+  const stopDrawing = () => {
+    if (!context) return;
+    context.closePath();
+    setIsDrawing(false);
+
+    // 描画内容をBase64形式で保存
+    const canvas = canvasRef.current;
+    if (canvas) {
+      const dataUrl = canvas.toDataURL("image/png");
+      onChange(dataUrl);
+    }
+  };
+
+  const clearCanvas = () => {
+    if (!context || !canvasRef.current) return;
+    context.clearRect(0, 0, canvasRef.current.width, canvasRef.current.height);
+    onChange("");
+  };
+
+  return (
+    <div className="m-4 bg-lightGray p-4">
+      <canvas
+        ref={canvasRef}
+        width={canvasWidth}
+        height={400}
+        onMouseDown={startDrawing}
+        onMouseMove={draw}
+        onMouseUp={stopDrawing}
+        onMouseLeave={stopDrawing}
+        className="cursor-crosshair rounded border border-lightGray"
+      />
+      <button
+        type="button"
+        onClick={clearCanvas}
+        className="mt-2 rounded bg-white px-4 py-2 hover:bg-gray"
+      >
+        クリア
+      </button>
+    </div>
+  );
+};

--- a/src/component/Drawing.tsx
+++ b/src/component/Drawing.tsx
@@ -105,7 +105,7 @@ export const Drawing: React.FC<DrawingProps> = ({
       <canvas
         ref={canvasRef}
         width={canvasWidth}
-        height={400}
+        height={300}
         onMouseDown={startDrawing}
         onMouseMove={draw}
         onMouseUp={stopDrawing}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -7,6 +7,7 @@ export type Memo = {
   title?: string;
   content: string;
   created_at: string;
+  drawing?: string;
   local_created_at: string;
   theme: Theme;
 }

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -7,7 +7,6 @@ export type Memo = {
   title?: string;
   content: string;
   created_at: string;
-  drawing?: string;
   local_created_at: string;
   theme: Theme;
 }


### PR DESCRIPTION
# 描画メモの保存と表示

## 変更内容
- 描画での入力フィールドを実装
- MemoListページとmemoListAllページに描画結果を表示
- 描画内容はテキストデータとしてDB（既存のcontent）に保存

## 動作確認項目
- [ ] 描画メモを作成時に正しく保存されること
- [ ] `MemoList`ページ（jotai管理）で描画データが正しく表示されること
- [ ] `MemoListAll`ページ（db管理）で描画データが正しく表示されること
- [ ] テキストメモの機能に影響がないこと

## 申し送り
テキストと描画を混ぜた処理はできません