### PR TITLE
feat: ユーザーの前回選択した入力タブをDBに保存・復元できるようにした

### DIFF
--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -50,15 +50,18 @@ export async function PUT(request: Request) {
       const userId = user?.data?.user?.id;
 
       const body = await request.json();
-      const { theme_count, time_limit } = body;
+      const { last_selected_input_type, theme_count, time_limit } = body;
 
       // upsertを使用して、レコードが存在しない場合は挿入、存在する場合は更新
       const { data, error } = await supabase
-        .from('user_settings')
+        .from("user_settings")
         .upsert({
           theme_count,
           time_limit,
           user_id: userId,
+          ...(last_selected_input_type !== undefined && {
+            last_selected_input_type,
+          }),
         })
         .select()
         .single();

--- a/src/services/settingsService.ts
+++ b/src/services/settingsService.ts
@@ -1,16 +1,24 @@
 import { createGet, createPut } from "@/services/api";
 import type { Setting } from "@/types/database";
 
+// 型拡張: Settingにlast_selected_input_typeを追加
+export type SettingWithInputType = Setting & { last_selected_input_type?: string };
+
 export const fetchSettings = async () => {
-  const { data } = await createGet<Setting>('settings');
+  const { data } = await createGet<SettingWithInputType>("settings");
   return data;
 };
 
-// 設定更新用の関数を追加
-export const updateSettings = async (theme_count: number, time_limit: string) => {
-  const { data } = await createPut<Setting>('settings', {
+// 設定更新用の関数を修正
+export const updateSettings = async (
+  theme_count: number,
+  time_limit: string,
+  last_selected_input_type?: string
+) => {
+  const { data } = await createPut<SettingWithInputType>("settings", {
     theme_count,
     time_limit,
+    ...(last_selected_input_type !== undefined && { last_selected_input_type }),
   });
   return data;
 };

--- a/src/services/settingsService.ts
+++ b/src/services/settingsService.ts
@@ -1,11 +1,8 @@
 import { createGet, createPut } from "@/services/api";
 import type { Setting } from "@/types/database";
 
-// 型拡張: Settingにlast_selected_input_typeを追加
-export type SettingWithInputType = Setting & { last_selected_input_type?: string };
-
 export const fetchSettings = async () => {
-  const { data } = await createGet<SettingWithInputType>("settings");
+  const { data } = await createGet<Setting>("settings");
   return data;
 };
 
@@ -15,7 +12,7 @@ export const updateSettings = async (
   time_limit: string,
   last_selected_input_type?: string
 ) => {
-  const { data } = await createPut<SettingWithInputType>("settings", {
+  const { data } = await createPut<Setting>("settings", {
     theme_count,
     time_limit,
     ...(last_selected_input_type !== undefined && { last_selected_input_type }),

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -12,6 +12,7 @@ export type Memo = {
 }
 
 export type Setting = {
-  theme_count: number,
-  time_limit :string,
-}
+  last_selected_input_type?: string;
+  theme_count: number;
+  time_limit: string;
+};

--- a/supabase/migrations/20241030100000_create_user_settings_table.sql
+++ b/supabase/migrations/20241030100000_create_user_settings_table.sql
@@ -2,7 +2,8 @@
 create table user_settings (
   user_id uuid references auth.users (id) on delete cascade primary key,
   theme_count integer default 10,
-  time_limit text default '60'
+  time_limit text default '60',
+  last_selected_input_type text NOT NULL DEFAULT 'text'
 );
 
 -- RLSを有効化


### PR DESCRIPTION
## 概要

- ユーザーがメモ入力画面で選択したタブ（テキスト入力 or 手書き入力）をDB（user_settingsテーブル）に保存し、次回アクセス時に自動で復元されるようにしました。

## 主な変更点

- user_settingsテーブルに `last_selected_input_type` カラムを追加
- 設定API（/api/settings）・サービス層で `last_selected_input_type` の取得・更新に対応
- MemoEditorPageでタブ選択状態をAPI経由で保存・復元するよう修正
- マイグレーションファイルを整理し、テーブル作成時にカラムが含まれるよう統合

## 動作確認

- タブを切り替えてページをリロードしても、前回選択したタブが復元されること
- DBリセット・マイグレーション適用後も正常に動作すること

---

ご確認よろしくお願いいたします。