### PR TITLE
Pj1 72（Setting Pageから直接パスワードを変更できる機能を追加）

### DIFF
--- a/src/app/(auth)/auth/reset-password/confirm/layout.tsx
+++ b/src/app/(auth)/auth/reset-password/confirm/layout.tsx
@@ -1,0 +1,40 @@
+import "@/styles/globals.scss";
+
+import { redirect } from "next/navigation";
+
+import { Header } from "@/component/Header";
+import { createSupabaseServerClient } from "@/utils/supabase/server";
+
+export const metadata = {
+  title: "パスワードリセット確認 - ThoughtKeeper",
+  description: "パスワードリセット確認ページ",
+};
+
+export default async function ResetPasswordConfirmLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const supabase = createSupabaseServerClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  // 既にログインしている場合は設定ページにリダイレクト
+  // （ログイン済みユーザーは設定ページから直接パスワードを変更する）
+  if (user) {
+    return redirect("/setting");
+  }
+
+  return (
+    <html lang="ja">
+      <body>
+        <Header />
+        <div className="flex justify-center">
+          <div className="min-h-screen w-full">{children}</div>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/src/app/(auth)/auth/reset-password/page.tsx
+++ b/src/app/(auth)/auth/reset-password/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useState } from "react";
 
 import { SubmitButton } from "../login/submit-button";
+import { sendPasswordResetEmail } from "@/services/authService";
 
 export default function ResetPasswordPage() {
   const [message, setMessage] = useState<{
@@ -33,30 +34,8 @@ export default function ResetPasswordPage() {
 
       console.log("Attempting to send reset password email to:", email);
 
-      const response = await fetch("/api/auth/reset-password", {
-        body: JSON.stringify({ email }),
-        headers: {
-          "Content-Type": "application/json",
-        },
-        method: "POST",
-      });
-
-      const data = await response.json();
-
-      if (!response.ok) {
-        console.error("Reset password error:", data.error);
-        setMessage({
-          text: data.error || "パスワードリセットに失敗しました",
-          type: "error",
-        });
-        return;
-      }
-
-      console.log("Password reset email sent successfully");
-      setMessage({
-        text: "パスワードリセット用のメールを送信しました。メールをご確認ください。",
-        type: "success",
-      });
+      const [success, msg] = await sendPasswordResetEmail(email);
+      setMessage({ text: msg, type: success ? "success" : "error" });
     } catch (error) {
       console.error("Unexpected error during password reset:", error);
       setMessage({ text: "予期しないエラーが発生しました。", type: "error" });

--- a/src/app/(authenticated)/setting/page.tsx
+++ b/src/app/(authenticated)/setting/page.tsx
@@ -4,8 +4,11 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import { MdOutlineClose } from "react-icons/md";
 
+import { SubmitButton } from "@/app/(auth)/auth/login/submit-button";
 import { Loader } from "@/component/Loader";
 import { useSettings } from "@/hooks/useSettings";
+import { useUser } from "@/hooks/useUser";
+import { sendPasswordResetEmail } from "@/services/authService";
 
 // テーマ数の入力コンポーネント
 const InputTargetCount = ({
@@ -84,16 +87,60 @@ const InputTargetTime = ({
 };
 
 export default function SettingPage() {
-  const { error, isLoading, settings, updateSettings } = useSettings();
+  const {
+    error: settingsError,
+    isLoading: isSettingsLoading,
+    settings,
+    updateSettings,
+  } = useSettings();
+  const { user, isLoading: isUserLoading, error: userError } = useUser();
 
-  if (isLoading) return <Loader />;
-  if (error) return <div>エラーが発生しました: {error.message}</div>;
+  const [message, setMessage] = useState<{
+    text: string;
+    type: "success" | "error";
+  } | null>(null);
+
+  const resetPassword = async () => {
+    try {
+      if (!user?.email) {
+        setMessage({
+          text: "ログインしているユーザーのメールアドレスが見つかりません",
+          type: "error",
+        });
+        return;
+      }
+      const email = user.email;
+
+      // バリデーション
+      // メールアドレスの形式チェックは、user.emailがSupabaseから来ているので不要
+
+      console.log("Attempting to send reset password email to:", email);
+
+      const [success, msg] = await sendPasswordResetEmail(email);
+      setMessage({ text: msg, type: success ? "success" : "error" });
+    } catch (error) {
+      console.error("Unexpected error during password reset:", error);
+      setMessage({ text: "予期しないエラーが発生しました。", type: "error" });
+    }
+  };
+
+  if (isSettingsLoading || isUserLoading) {
+    return <Loader />;
+  }
+  if (settingsError) {
+    return <div>エラーが発生しました: {settingsError.message}</div>;
+  }
+  if (userError) {
+    return (
+      <div>ユーザー情報の取得中にエラーが発生しました: {userError.message}</div>
+    );
+  }
 
   const themeCount = settings?.theme_count ?? 10;
   const timeLimit = settings?.time_limit ?? "60";
 
   return (
-    <div className="mx-3 mt-6 flex justify-between p-8 shadow lg:mt-0 dark:shadow-lightGray">
+    <div className="mx-3 mt-6 flex justify-between p-8 shadow dark:shadow-lightGray lg:mt-0">
       <div className="flex-1">
         <form onSubmit={(e) => e.preventDefault()}>
           <div className="mb-6 md:flex">
@@ -134,6 +181,36 @@ export default function SettingPage() {
             </div>
           </div>
         </form>
+
+        {/* パスワードリセットセクション */}
+        <div className="mt-10">
+          <h2 className="mb-6 text-xl font-bold">パスワードの変更</h2>
+          <p className="text-gray-600 mb-6 text-sm">
+            現在ログイン中のメールアドレス（{user?.email}
+            ）にパスワードリセット用のリンクをお送りします。
+          </p>
+          <form className="flex flex-col gap-2">
+            <SubmitButton
+              formAction={resetPassword}
+              className="mb-2 rounded-md bg-green-700 px-4 py-2 text-foreground"
+              pendingText="送信中..."
+            >
+              リセットリンクを送信
+            </SubmitButton>
+          </form>
+
+          {message && (
+            <p
+              className={`mt-4 p-4 text-center ${
+                message.type === "success"
+                  ? "rounded border border-green-200 bg-green-50 text-green-600"
+                  : "rounded border border-red-200 bg-red-50 text-tomato"
+              }`}
+            >
+              {message.text}
+            </p>
+          )}
+        </div>
       </div>
       <Link className="pl-10 text-xl" href="/">
         <MdOutlineClose />

--- a/src/app/(authenticated)/setting/page.tsx
+++ b/src/app/(authenticated)/setting/page.tsx
@@ -6,9 +6,9 @@ import { MdOutlineClose } from "react-icons/md";
 
 import { SubmitButton } from "@/app/(auth)/auth/login/submit-button";
 import { Loader } from "@/component/Loader";
+import { usePasswordReset } from "@/hooks/usePasswordReset";
 import { useSettings } from "@/hooks/useSettings";
 import { useUser } from "@/hooks/useUser";
-import { sendPasswordResetEmail } from "@/services/authService";
 
 // テーマ数の入力コンポーネント
 const InputTargetCount = ({
@@ -94,35 +94,51 @@ export default function SettingPage() {
     updateSettings,
   } = useSettings();
   const { user, isLoading: isUserLoading, error: userError } = useUser();
+  const {
+    updatePassword,
+    isLoading: isPasswordUpdating,
+    error: passwordError,
+    success: passwordSuccess,
+  } = usePasswordReset();
 
-  const [message, setMessage] = useState<{
-    text: string;
-    type: "success" | "error";
-  } | null>(null);
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [passwordMatchMessage, setPasswordMatchMessage] = useState("");
+  const [showPasswordMatchMessage, setShowPasswordMatchMessage] =
+    useState(false);
 
-  const resetPassword = async () => {
-    try {
-      if (!user?.email) {
-        setMessage({
-          text: "ログインしているユーザーのメールアドレスが見つかりません",
-          type: "error",
-        });
-        return;
-      }
-      const email = user.email;
-
-      // バリデーション
-      // メールアドレスの形式チェックは、user.emailがSupabaseから来ているので不要
-
-      console.log("Attempting to send reset password email to:", email);
-
-      const [success, msg] = await sendPasswordResetEmail(email);
-      setMessage({ text: msg, type: success ? "success" : "error" });
-    } catch (error) {
-      console.error("Unexpected error during password reset:", error);
-      setMessage({ text: "予期しないエラーが発生しました。", type: "error" });
+  // リアルタイムバリデーション
+  useEffect(() => {
+    if (confirmPassword && password !== confirmPassword) {
+      setPasswordMatchMessage("パスワードが一致しません");
+      setShowPasswordMatchMessage(true);
+    } else if (confirmPassword && password === confirmPassword) {
+      setPasswordMatchMessage("パスワードが一致しました✅");
+      setShowPasswordMatchMessage(true);
+    } else {
+      setShowPasswordMatchMessage(false);
     }
+  }, [password, confirmPassword]);
+
+  const handlePasswordUpdate = async () => {
+    if (!password || !confirmPassword) {
+      return;
+    }
+
+    if (password !== confirmPassword) {
+      return;
+    }
+
+    await updatePassword(password, confirmPassword);
   };
+
+  // パスワード更新成功時にフォームをクリア
+  useEffect(() => {
+    if (passwordSuccess) {
+      setPassword("");
+      setConfirmPassword("");
+    }
+  }, [passwordSuccess]);
 
   if (isSettingsLoading || isUserLoading) {
     return <Loader />;
@@ -182,32 +198,103 @@ export default function SettingPage() {
           </div>
         </form>
 
-        {/* パスワードリセットセクション */}
+        {/* パスワード変更セクション */}
         <div className="mt-10">
           <h2 className="mb-6 text-xl font-bold">パスワードの変更</h2>
           <p className="text-gray-600 mb-6 text-sm">
-            現在ログイン中のメールアドレス（{user?.email}
-            ）にパスワードリセット用のリンクをお送りします。
+            現在ログイン中のアカウント（{user?.email}
+            ）のパスワードを直接変更できます。
           </p>
-          <form className="flex flex-col gap-2">
-            <SubmitButton
-              formAction={resetPassword}
-              className="mb-2 rounded-md bg-green-700 px-4 py-2 text-foreground"
-              pendingText="送信中..."
+          <form
+            className="flex flex-col gap-2"
+            onSubmit={(e) => {
+              e.preventDefault();
+              handlePasswordUpdate();
+            }}
+          >
+            <label className="text-base font-semibold" htmlFor="newPassword">
+              新しいパスワード
+            </label>
+            <input
+              className="mb-4 rounded-md border bg-inherit px-4 py-2"
+              type="password"
+              name="newPassword"
+              id="newPassword"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="••••••••"
+              minLength={8}
+              required
+              disabled={isPasswordUpdating}
+            />
+
+            <label
+              className="text-base font-semibold"
+              htmlFor="confirmNewPassword"
             >
-              リセットリンクを送信
-            </SubmitButton>
+              パスワード確認
+            </label>
+            <input
+              className="mb-4 rounded-md border bg-inherit px-4 py-2"
+              type="password"
+              name="confirmNewPassword"
+              id="confirmNewPassword"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              placeholder="••••••••"
+              minLength={8}
+              required
+              disabled={isPasswordUpdating}
+            />
+
+            {/* リアルタイムバリデーションメッセージ */}
+            {showPasswordMatchMessage && (
+              <div className="mb-4 text-sm">
+                <p
+                  className={
+                    passwordMatchMessage.includes("一致しました")
+                      ? "text-green-500"
+                      : "text-red-500"
+                  }
+                >
+                  {passwordMatchMessage}
+                </p>
+              </div>
+            )}
+
+            <div className="text-gray-500 mb-4 text-xs">
+              <p>パスワードは以下の条件を満たす必要があります：</p>
+              <ul className="list-disc pl-4">
+                <li>8文字以上</li>
+                <li>小文字を含む</li>
+                <li>大文字を含む</li>
+                <li>数字を含む</li>
+              </ul>
+            </div>
+
+            <button
+              type="submit"
+              className="mb-2 rounded-md bg-green-700 px-4 py-2 text-foreground disabled:opacity-50"
+              disabled={
+                isPasswordUpdating ||
+                !password ||
+                !confirmPassword ||
+                password !== confirmPassword
+              }
+            >
+              {isPasswordUpdating ? "更新中..." : "パスワードを変更"}
+            </button>
           </form>
 
-          {message && (
-            <p
-              className={`mt-4 p-4 text-center ${
-                message.type === "success"
-                  ? "rounded border border-green-200 bg-green-50 text-green-600"
-                  : "rounded border border-red-200 bg-red-50 text-tomato"
-              }`}
-            >
-              {message.text}
+          {passwordSuccess && (
+            <p className="mt-4 rounded border border-green-200 bg-green-50 p-4 text-center text-green-600">
+              {passwordSuccess}
+            </p>
+          )}
+
+          {passwordError && (
+            <p className="mt-4 rounded border border-red-200 bg-red-50 p-4 text-center text-tomato">
+              {passwordError}
             </p>
           )}
         </div>

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -1,27 +1,34 @@
 "use client";
 import { useAtom } from "jotai";
 import ky from "ky";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import type { User } from "@/store";
 import { userStateAtom } from "@/store";
 
 export function useUser() {
   const [user, setUser] = useAtom(userStateAtom);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
 
   useEffect(() => {
     const fetchUser = async () => {
       try {
-        const { user } = await ky.get('/api/auth/user').json<{ user: User | null }>();
+        const { user } = await ky
+          .get("/api/auth/user")
+          .json<{ user: User | null }>();
         setUser(user);
+        setIsLoading(false);
       } catch (error) {
-        console.error('Failed to fetch user:', error);
+        console.error("Failed to fetch user:", error);
         setUser(null);
+        setError(error instanceof Error ? error : new Error(String(error)));
+        setIsLoading(false);
       }
     };
 
     fetchUser();
   }, [setUser]);
 
-  return { user };
+  return { user, isLoading, error };
 }

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -1,0 +1,24 @@
+export async function sendPasswordResetEmail(email: string): Promise<[true, string] | [false, string]> {
+  try {
+    const response = await fetch("/api/auth/reset-password", {
+      body: JSON.stringify({ email }),
+      headers: {
+        "Content-Type": "application/json",
+      },
+      method: "POST",
+    });
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      console.error("Reset password error:", data.error);
+      return [false, data.error || "パスワードリセットに失敗しました"];
+    }
+
+    console.log("Password reset email sent successfully");
+    return [true, "パスワードリセット用のメールを送信しました。メールをご確認ください。"];
+  } catch (error) {
+    console.error("Unexpected error during password reset:", error);
+    return [false, "予期しないエラーが発生しました。"];
+  }
+}


### PR DESCRIPTION
## 概要

Setting Pageから直接パスワードを変更できる機能を追加しました。また、ログイン前後で共通して使用できる`usePasswordReset`フックを活用し、パスワードリセット機能を改善しました。

## 変更内容

### 🎯 主な機能追加

1. **Setting Pageに直接パスワード変更フォームを追加**
   - ログイン中にメールリンクを送信せず、直接新しいパスワードを設定可能
   - リアルタイムバリデーション（パスワード一致チェック）
   - パスワード変更成功時にフォームを自動クリア

2. **ログイン済みユーザーの保護**
   - ログイン済みユーザーがパスワードリセット確認ページ（`/auth/reset-password/confirm`）にアクセスした場合、自動的に設定ページにリダイレクト
   - 誤ってメールリンクをクリックしても適切に処理

3. **共通フックの活用**
   - `usePasswordReset`フックをログイン前後の両方で使用可能に
   - コードの重複を削減し、保守性を向上

## 変更ファイル

- `src/app/(authenticated)/setting/page.tsx`
  - メールリンク送信から直接パスワード変更フォームに変更
  - `usePasswordReset`フックの`updatePassword`を使用

- `src/app/(auth)/auth/reset-password/confirm/layout.tsx` (新規)
  - ログイン済みユーザーのリダイレクト処理を追加

## 動作フロー

### ログイン中のパスワード変更
1. Setting Page → 「パスワードの変更」セクション
2. 新しいパスワードとパスワード確認を入力
3. 「パスワードを変更」ボタンをクリック
4. バックエンドでパスワードが直接更新される
5. 次回ログアウト後は新しいパスワードでログイン可能

### ログイン前のパスワードリセット（従来通り）
1. `/auth/reset-password` → メールアドレスを入力
2. メールリンクをクリック
3. `/auth/reset-password/confirm` → 新しいパスワードを設定

## テスト項目

- [ ] Setting Pageから直接パスワード変更ができること
- [ ] パスワード一致バリデーションが動作すること
- [ ] パスワード変更成功時にフォームがクリアされること
- [ ] ログイン済みユーザーがパスワードリセット確認ページにアクセスした場合、設定ページにリダイレクトされること
- [ ] ログイン前のパスワードリセット（メールリンク経由）が正常に動作すること
- [ ] 次回ログアウト後、新しいパスワードでログインできること

## 関連Issue

#72